### PR TITLE
Change setState convention to mutateState

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Provide you can create immutable state easily with mutable way.
 import { useMutative } from 'use-mutative';
 
 export function App() {
-  const [state, setState] = useMutative({
+  const [state, mutateState] = useMutative({
     foo: 'bar',
     list: [{ text: 'todo' }],
   });
@@ -42,7 +42,7 @@ export function App() {
       <button
         onClick={() => {
           // set value with draft mutable
-          setState((draft) => {
+          mutateState((draft) => {
             draft.foo = `${draft.foo} 2`;
             draft.list.push({ text: 'todo 2' });
           });
@@ -53,7 +53,7 @@ export function App() {
       <button
         onClick={() => {
           // also can override value directly
-          setState({
+          mutateState({
             foo: 'bar 2',
             list: [{ text: 'todo 2' }],
           });
@@ -117,7 +117,7 @@ More detail about `use-mutative` can be found in [API docs](https://github.com/m
 In some cases, you may want to get that patches from your update, we can pass `{ enablePatches: true }` options in `useMutative()` or `useMutativeReducer()`, that can provide you the ability to get that patches from pervious action.
 
 ```tsx
-const [state, setState, patches, inversePatches] = useMutative(initState, {
+const [state, mutateState, patches, inversePatches] = useMutative(initState, {
   enablePatches: true,
 });
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ Provide you can create immutable state easily with mutable way.
 import { useMutative } from 'use-mutative';
 
 export function App() {
-  const [state, setState] = useMutative({
+  const [state, mutateState] = useMutative({
     foo: 'bar',
     list: [{ text: 'todo' }],
   });
@@ -44,7 +44,7 @@ export function App() {
       <button
         onClick={() => {
           // set value with draft mutable
-          setState((draft) => {
+          mutateState((draft) => {
             draft.foo = `${draft.foo} 2`;
             draft.list.push({ text: 'todo 2' });
           });
@@ -55,7 +55,7 @@ export function App() {
       <button
         onClick={() => {
           // also can override value directly
-          setState({
+          mutateState({
             foo: 'bar 2',
             list: [{ text: 'todo 2' }],
           });
@@ -118,7 +118,7 @@ More detail about `use-mutative` can be found in [API docs](https://github.com/m
 In some cases, you may want to get that patches from your update, we can pass `{ enablePatches: true }` options in `useMutative` or `useMutativeReducer`, that can provide you the ability to get that patches from pervious action.
 
 ```tsx
-const [state, setState, patches, inversePatches] = useMutative(initState, {
+const [state, mutateState, patches, inversePatches] = useMutative(initState, {
   enablePatches: true,
 });
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -142,9 +142,9 @@ import { act, renderHook } from '@testing-library/react';
 import { useMutative } from '../src/index';
 
 const { result } = renderHook(() => useMutative({ items: [1] }));
-const [state, setState] = result.current;
+const [state, mutateState] = result.current;
 act(() =>
-  setState((draft) => {
+  mutateState((draft) => {
     draft.items.push(2);
   })
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,9 +52,9 @@ type Result<S, O extends PatchesOptions, F extends boolean> = O extends
  * import { useMutative } from '../src/index';
  *
  * const { result } = renderHook(() => useMutative({ items: [1] }));
- * const [state, setState] = result.current;
+ * const [state, mutateState] = result.current;
  * act(() =>
- *   setState((draft) => {
+ *   mutateState((draft) => {
  *     draft.items.push(2);
  *   })
  * );
@@ -94,11 +94,11 @@ function useMutative<
   currentCount += 1;
   renderCount.current += 1;
   //#endregion
-  const [state, setState] = useState(() =>
+  const [state, mutateState] = useState(() =>
     typeof initialValue === 'function' ? initialValue() : initialValue
   );
   const updateState = useCallback((updater: any) => {
-    setState((latest: any) => {
+    mutateState((latest: any) => {
       const updaterFn = typeof updater === 'function' ? updater : () => updater;
       const result = create(latest, updaterFn, options);
       if (options?.enablePatches) {
@@ -108,7 +108,7 @@ function useMutative<
           renderCount.current === count.current + 1
         ) {
           Array.prototype.push.apply(patchesRef.current.patches, result[1]);
-          // `inversePatches` should be in reverse order when multiple setState() executions
+          // `inversePatches` should be in reverse order when multiple mutateState() executions
           Array.prototype.unshift.apply(
             patchesRef.current.inversePatches,
             result[2]
@@ -277,7 +277,7 @@ function useMutativeReducer<
           renderCount.current === count.current + 1
         ) {
           Array.prototype.push.apply(patchesRef.current.patches, result[1]);
-          // `inversePatches` should be in reverse order when multiple setState() executions
+          // `inversePatches` should be in reverse order when multiple mutateState() executions
           Array.prototype.unshift.apply(
             patchesRef.current.inversePatches,
             result[2]

--- a/test/index.0.snap.ts
+++ b/test/index.0.snap.ts
@@ -3,9 +3,9 @@ import { act, renderHook } from '@testing-library/react';
 import { useMutative } from '../src/index';
 
 const { result } = renderHook(() => useMutative({ items: [1] }));
-const [state, setState] = result.current;
+const [state, mutateState] = result.current;
 act(() =>
-  setState((draft) => {
+  mutateState((draft) => {
     draft.items.push(2);
   })
 );

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -12,9 +12,9 @@ test('test "mutative" function', () => {
 describe('useMutative', () => {
   it('[useMutative] with normal init state', () => {
     const { result } = renderHook(() => useMutative({ items: [1] }));
-    const [state, setState] = result.current;
+    const [state, mutateState] = result.current;
     act(() =>
-      setState((draft) => {
+      mutateState((draft) => {
         draft.items.push(2);
       })
     );
@@ -29,12 +29,12 @@ describe('useMutative', () => {
 
     expect(result.current).toHaveLength(2);
 
-    const [state, setState] = result.current;
+    const [state, mutateState] = result.current;
     expect(state).toEqual([1]);
-    expect(typeof setState).toBe('function');
+    expect(typeof mutateState).toBe('function');
 
     // eslint-disable-next-line prettier/prettier
-    act(() => setState(() => [1, 2]));
+    act(() => mutateState(() => [1, 2]));
 
     const [state2] = result.current;
     expect(state2).toEqual([1, 2]);
@@ -47,11 +47,11 @@ describe('useMutative', () => {
 
     expect(result.current).toHaveLength(2);
 
-    const [state, setState] = result.current;
+    const [state, mutateState] = result.current;
     expect(state).toEqual([1]);
-    expect(typeof setState).toBe('function');
+    expect(typeof mutateState).toBe('function');
 
-    act(() => setState([1, 2]));
+    act(() => mutateState([1, 2]));
 
     const [state2] = result.current;
     expect(state2).toEqual([1, 2]);
@@ -66,12 +66,12 @@ describe('useMutative', () => {
 
     expect(result.current).toHaveLength(2);
 
-    const [state, setState] = result.current;
+    const [state, mutateState] = result.current;
     expect(state).toEqual({ items: [1] });
-    expect(typeof setState).toBe('function');
+    expect(typeof mutateState).toBe('function');
 
     act(() =>
-      setState((draft) => {
+      mutateState((draft) => {
         draft.items.push(2);
       })
     );
@@ -87,13 +87,13 @@ describe('useMutative', () => {
       })
     );
 
-    const [state, setState] = result.current;
+    const [state, mutateState] = result.current;
     act(() => {
-      setState((draft) => {
+      mutateState((draft) => {
         draft.items.push(2);
       });
 
-      setState((draft) => {
+      mutateState((draft) => {
         draft.items.push(3);
       });
     });
@@ -113,13 +113,13 @@ describe('useMutative', () => {
 
     expect(result.current).toHaveLength(4);
 
-    const [state, setState, patches, inversePatches] = result.current;
+    const [state, mutateState, patches, inversePatches] = result.current;
     expect(state).toEqual({ items: [1] });
     expect(patches).toEqual([]);
     expect(inversePatches).toEqual([]);
 
     act(() =>
-      setState((draft) => {
+      mutateState((draft) => {
         draft.items.push(2);
       })
     );
@@ -134,7 +134,7 @@ describe('useMutative', () => {
       { op: 'replace', path: ['items', 'length'], value: 1 },
     ]);
 
-    act(() => setState({ items: [123] }));
+    act(() => mutateState({ items: [123] }));
     const [state3] = result.current;
     expect(state3).toEqual({ items: [123] });
   });
@@ -147,28 +147,28 @@ describe('useMutative', () => {
 
     expect(result.current).toHaveLength(4);
 
-    let [state, setState, patches, inversePatches] = result.current;
+    let [state, mutateState, patches, inversePatches] = result.current;
     expect(state).toEqual([1]);
     expect(patches).toEqual([]);
     expect(inversePatches).toEqual([]);
 
     act(() => {
-      setState((draft) => {
+      mutateState((draft) => {
         draft.push(2);
         draft.push(999);
       });
-      setState((draft) => {
+      mutateState((draft) => {
         draft.push(3);
         draft.push(4);
       });
-      setState((draft) => {
+      mutateState((draft) => {
         draft.shift();
         draft.push(5);
       });
     });
 
-    [state, setState, patches, inversePatches] = result.current;
-    const mutateState = () => {
+    [state, mutateState, patches, inversePatches] = result.current;
+    const alterState = () => {
       const state = [1];
       state.push(2);
       state.push(999);
@@ -182,7 +182,7 @@ describe('useMutative', () => {
     };
     expect(baseState).toEqual([1]);
     expect(state).toEqual([2, 999, 3, 4, 5]);
-    expect(mutateState()).toEqual([2, 999, 3, 4, 5]);
+    expect(alterState()).toEqual([2, 999, 3, 4, 5]);
     expect(patches).toEqual([
       { op: 'add', path: [1], value: 2 },
       { op: 'add', path: [2], value: 999 },
@@ -216,18 +216,20 @@ describe('useMutative', () => {
       ];
     });
 
-    let [[state, setState, patches, inversePatches], [state0, setState0]] =
-      result.current;
+    let [
+      [state, mutateState, patches, inversePatches],
+      [state0, mutateState0],
+    ] = result.current;
     expect(state0).toEqual(0);
     expect(state).toEqual([1]);
     expect(patches).toEqual([]);
     expect(inversePatches).toEqual([]);
 
     act(() => {
-      setState0(1);
+      mutateState0(1);
     });
 
-    [[state, setState, patches, inversePatches], [state0, setState0]] =
+    [[state, mutateState, patches, inversePatches], [state0, mutateState0]] =
       result.current;
     expect(state0).toEqual(1);
     expect(state).toEqual([1]);
@@ -235,23 +237,23 @@ describe('useMutative', () => {
     expect(inversePatches).toEqual([]);
 
     act(() => {
-      setState((draft: any) => {
+      mutateState((draft: any) => {
         draft.push(2);
         draft.push(999);
       });
-      setState((draft: any) => {
+      mutateState((draft: any) => {
         draft.push(3);
         draft.push(4);
       });
-      setState((draft: any) => {
+      mutateState((draft: any) => {
         draft.shift();
         draft.push(5);
       });
     });
 
-    [[state, setState, patches, inversePatches], [state0, setState0]] =
+    [[state, mutateState, patches, inversePatches], [state0, mutateState0]] =
       result.current;
-    const mutateState = () => {
+    const alterState = () => {
       const state = [1];
       state.push(2);
       state.push(999);
@@ -265,7 +267,7 @@ describe('useMutative', () => {
     };
     expect(baseState).toEqual([1]);
     expect(state).toEqual([2, 999, 3, 4, 5]);
-    expect(mutateState()).toEqual([2, 999, 3, 4, 5]);
+    expect(alterState()).toEqual([2, 999, 3, 4, 5]);
     expect(patches).toEqual([
       { op: 'add', path: [1], value: 2 },
       { op: 'add', path: [2], value: 999 },
@@ -299,28 +301,28 @@ describe('useMutative', () => {
 
     expect(result.current).toHaveLength(4);
 
-    let [state, setState, patches, inversePatches] = result.current;
+    let [state, mutateState, patches, inversePatches] = result.current;
     expect(state).toEqual([1]);
     expect(patches).toEqual([]);
     expect(inversePatches).toEqual([]);
 
     act(() => {
-      setState((draft) => {
+      mutateState((draft) => {
         draft.push(2);
         draft.push(999);
       });
-      setState((draft) => {
+      mutateState((draft) => {
         draft.push(3);
         draft.push(4);
       });
-      setState((draft) => {
+      mutateState((draft) => {
         draft.shift();
         draft.push(5);
       });
     });
 
-    [state, setState, patches, inversePatches] = result.current;
-    const mutateState = () => {
+    [state, mutateState, patches, inversePatches] = result.current;
+    const alterState = () => {
       const state = [1];
       state.push(2);
       state.push(999);
@@ -334,7 +336,7 @@ describe('useMutative', () => {
     };
     expect(baseState).toEqual([1]);
     expect(state).toEqual([2, 999, 3, 4, 5]);
-    expect(mutateState()).toEqual([2, 999, 3, 4, 5]);
+    expect(alterState()).toEqual([2, 999, 3, 4, 5]);
     expect(patches).toEqual([
       { op: 'add', path: [1], value: 2 },
       { op: 'add', path: [2], value: 999 },
@@ -371,18 +373,20 @@ describe('useMutative', () => {
       { wrapper: React.StrictMode }
     );
 
-    let [[state, setState, patches, inversePatches], [state0, setState0]] =
-      result.current;
+    let [
+      [state, mutateState, patches, inversePatches],
+      [state0, mutateState0],
+    ] = result.current;
     expect(state0).toEqual(0);
     expect(state).toEqual([1]);
     expect(patches).toEqual([]);
     expect(inversePatches).toEqual([]);
 
     act(() => {
-      setState0(1);
+      mutateState0(1);
     });
 
-    [[state, setState, patches, inversePatches], [state0, setState0]] =
+    [[state, mutateState, patches, inversePatches], [state0, mutateState0]] =
       result.current;
     expect(state0).toEqual(1);
     expect(state).toEqual([1]);
@@ -390,23 +394,23 @@ describe('useMutative', () => {
     expect(inversePatches).toEqual([]);
 
     act(() => {
-      setState((draft: any) => {
+      mutateState((draft: any) => {
         draft.push(2);
         draft.push(999);
       });
-      setState((draft: any) => {
+      mutateState((draft: any) => {
         draft.push(3);
         draft.push(4);
       });
-      setState((draft: any) => {
+      mutateState((draft: any) => {
         draft.shift();
         draft.push(5);
       });
     });
 
-    [[state, setState, patches, inversePatches], [state0, setState0]] =
+    [[state, mutateState, patches, inversePatches], [state0, mutateState0]] =
       result.current;
-    const mutateState = () => {
+    const alterState = () => {
       const state = [1];
       state.push(2);
       state.push(999);
@@ -420,7 +424,7 @@ describe('useMutative', () => {
     };
     expect(baseState).toEqual([1]);
     expect(state).toEqual([2, 999, 3, 4, 5]);
-    expect(mutateState()).toEqual([2, 999, 3, 4, 5]);
+    expect(alterState()).toEqual([2, 999, 3, 4, 5]);
     expect(patches).toEqual([
       { op: 'add', path: [1], value: 2 },
       { op: 'add', path: [2], value: 999 },


### PR DESCRIPTION
Fixes #9 .

Not sure if I got the commit messages right. Also updated source code and tests to follow this convention.

On the tests, I needed to rename the already existing `mutateState` to `alterState`. Can change further as needed.